### PR TITLE
main entry became to 'dist/siema.min.js'

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "siema",
   "version": "1.0.2",
   "description": "Lightweight and simple carousel with no dependencies",
-  "main": "src/siema.js",
+  "main": "dist/siema.min.js",
   "devDependencies": {
     "babel-cli": "6.18.0",
     "babel-plugin-transform-object-assign": "6.8.0",


### PR DESCRIPTION
When you use 'siema' with webpack loaders like this:
{
    test: /\.js?$/,
    exclude: /(node_modules|bower_components)/,
    loader: 'babel',
},

everything works fine, but if you want to use UglifyJsPlugin you get an error message like this:

ERROR in app.js from UglifyJs
SyntaxError: Unexpected token: punc ()) [./~/siema/src/siema.js:30,0]

Reason of error is 'main' from package.json

