### PR TITLE
improve detection when dragged element is a link

### DIFF
--- a/src/siema.js
+++ b/src/siema.js
@@ -533,9 +533,15 @@ export default class Siema {
       // if dragged element is a link
       // mark preventClick prop as a true
       // to detemine about browser redirection later on
-      if (e.target.nodeName === 'A') {
-        this.drag.preventClick = true;
-      }
+
+      let target = e.target
+      do {
+        if (target.nodeName === 'A') {
+          this.drag.preventClick = true;
+          break
+        }
+        target = target.parentNode
+      } while (target != null)
 
       this.drag.endX = e.pageX;
       this.selector.style.cursor = '-webkit-grabbing';


### PR DESCRIPTION
I have a few cases where the A tag detection is not working.  It is usually a SPAN or P tag within the A tag that is the event target.  This PR looks up the dom tree to find an A tag, and fixes the issue.