### PR TITLE
show only as many slides as available

### DIFF
--- a/src/siema.js
+++ b/src/siema.js
@@ -157,7 +157,7 @@ export default class Siema {
    * Build a sliderFrame and slide to a current item.
    */
   buildSliderFrame() {
-    const widthItem = this.selectorWidth / this.perPage;
+    const widthItem = this.selectorWidth / Math.min(this.perPage, this.innerElements.length);
     const itemsToBuild = this.config.loop ? this.innerElements.length + (2 * this.perPage) : this.innerElements.length;
 
     // Create frame and apply styling


### PR DESCRIPTION
If i pass `perPage: 9` and only have 5 slides, Siema used to show 9 slide-slots. Now Siema calculates the width accordingly and shows only 5 slides.