### PR TITLE
overflow auto to height 0 in sliderFrame

### DIFF
--- a/src/siema.js
+++ b/src/siema.js
@@ -162,6 +162,7 @@ export default class Siema {
 
     // Create frame and apply styling
     this.sliderFrame = document.createElement('div');
+    this.sliderFrame.style.overflowY = 'auto';
     this.sliderFrame.style.width = `${widthItem * itemsToBuild}px`;
     this.enableTransition();
 


### PR DESCRIPTION
When a user try to customize the slider in some cases height 0 in the sliderFrame avoid to change the position of the Siema.