### PR TITLE
Do not reload carousel on scroll down on mobile devices

### DIFF
--- a/src/siema.js
+++ b/src/siema.js
@@ -407,6 +407,10 @@ export default class Siema {
    * When window resizes, resize slider components as well
    */
   resizeHandler() {
+    if (this.selector.offsetWidth === this.selectorWidth) {
+      return;
+    }
+
     // update perPage number dependable of user value
     this.resolveSlidesNumber();
 


### PR DESCRIPTION
Address bar is hidden on scroll down on most mobile devices, which triggers a resize event. However Siema does not rely on height, hence the resize event should be ignored to avoid recreating the DOM for nothing.

This is important for any carousel that relies on DOM construction (ex: videos).

I'm aware that the repo is not actively maintained, but sending this PR in case in can still be of help to others.